### PR TITLE
Switched from browserouter to hashrouter for better routing performace

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createHashRouter, RouterProvider } from "react-router-dom";
 import "./index.css";
 import LandingPage, { action } from "./pages/LandingPage";
 import ChatPage from "./pages/ChatPage";
 
-const router = createBrowserRouter([
+const router = createHashRouter([
   {
     path: "/",
     children: [


### PR DESCRIPTION
I encountered an issue with the router pages in my application, which frequently displayed a "page not found" error, as shown in the screenshot below:

![image](https://github.com/user-attachments/assets/82218ddd-934c-4153-a106-c58af0760dd1)

To resolve this issue on Netlify and enhance performance, I switched from `BrowserRouter` to `HashRouter`. This change has effectively addressed the problem and improved the overall performance of the application.